### PR TITLE
Added a simple Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+compiler: gcc
+
+# Install dependencies
+install: sudo apt-get install libsnappy-dev liblzma-dev asciidoc source-highlight
+
+# Custom build command
+script: make clean json2avro
+
+# Cache APT dependencies
+cache:
+  apt: true


### PR DESCRIPTION
This PR adds a simple Travis CI build file that installs dependencies and makes sure `json2avro` build finishes successfully.
