### PR TITLE
Fix builds on old CMake versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
-
 json2avro: json2avro.c avrolib/lib/libavro.so
 	cc -o json2avro json2avro.c avrolib/lib/libavro.a -I avrolib/include -I avro-c/jansson/src -lz -llzma -lsnappy
 
 avrolib/lib/libavro.so:
-	cd avro-c && mkdir -p build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=../../avrolib -DCMAKE_BUILD_TYPE=Debug && make && make install
+	mkdir -p avro-c/build
+	cd avro-c/build && cmake .. -DCMAKE_INSTALL_PREFIX=../../avrolib -DCMAKE_BUILD_TYPE=Debug
+	cd avro-c/build && make
+	test -f avro-c/build/avro-c.pc && mv avro-c/build/avro-c.pc avro-c/build/src/ || true
+	cd avro-c/build && make install
 
 clean:
 	rm -rf avrolib


### PR DESCRIPTION
On older cmake releases (like the one shipped with CentOS 6) the build process fails to find `avro-c.pc` file during `make install`. This patch makes sure the file is in the right place by moving it to `src` directory before performing `make install` step (it only does that when the file is in the wrong place).

For more information about the issue, please check out [AVRO-1222](https://issues.apache.org/jira/browse/AVRO-1222)
