### PR TITLE
Multiple input files support

### DIFF
--- a/json2avro.c
+++ b/json2avro.c
@@ -294,13 +294,11 @@ void process_file(char *json_bucket, avro_file_writer_t out, avro_schema_t schem
     json_file = strtok(json_bucket, " ");
 
     while ((json_file != NULL)) {
-        if (strcmp(json_file, "-") == 0) {
+        if (strcmp(json_file, "-") == 0)
             input = stdin;
-            json = json_loadf(input, JSON_DISABLE_EOF_CHECK, &err);
-        } else {
+        else
             input = fopen(json_file, "r");
-            json = json_loadf(input, JSON_DISABLE_EOF_CHECK, &err);
-        }
+        json = json_loadf(input, JSON_DISABLE_EOF_CHECK, &err);
         while (!feof(input)) {
             n++;
             if (verbose && !(n % 1000))


### PR DESCRIPTION
We're heavily using this tool to convert a couple of GBs of JSON files into AVRO every day.
It was useful for me to have this tool to accept more JSON files as input, hence my commit here.
If you need to convert a batch of json files, originally, json2avro could only be used like this:

cat file1.json file2.json file3.json | json2avro -S schema_file output.avro

With this patch, json2avro can also be used like this:

json2avro -S schema_files file1.json file2.json file3.json output.avro

eliminating thus the cat utility or any other utility used to concatenate the input files.
The performance improvement is between 1 and 1.5 seconds for a batch of 160MB of JSON files, when running json2avro with multiple input files. 
