### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ some elements might be missing or of wrong type, which is not
 currently possible with the standard avro-tools fromjson option.
 
 Since in a conversion from JSON *schema resolution* is technically not
-applicable (becasue JSON is not Avro), json2avro mimics schema
+applicable (because JSON is not Avro), json2avro mimics schema
 resolution behavior by attemptin to use the defaults specified in the
 schema if the corresponding JSON element is missing as well as
 attempting to resolve unions by trying each type until one succeeds.


### PR DESCRIPTION
@grisha, I've corrected a typographical error in the documentation of the [json2avro](https://github.com/grisha/json2avro) project. Specifically, I've changed becasue to because. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.